### PR TITLE
Remove private

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.1",
   "description": "nodejs sdk for the smartcar platform",
   "main": "index.js",
-  "private": true,
   "author": "Smartcar <hello@smartcar.com> (https://smartcar.com)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Overview

`"private": true` was set in the package.json which prevented the deploy.

# Changes

Remove `"private": true` from package.json.