### PR TITLE
fix(sdk): Added a tolerance for expiration

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ const Promise = require('bluebird');
 const _ = require('lodash');
 
 const util = require('./lib/util');
+// Tolerance for expiration measured in milliseconds
+const TOLERANCE = 10 * 1000;
 
 /* eslint-disable global-require */
 /** @exports smartcar */
@@ -31,7 +33,7 @@ smartcar.expired = function(access) {
     throw new TypeError('"access.expiration" argument must be a valid ISO date string');
   }
 
-  return Date.now() > expiration;
+  return Date.now() > expiration - TOLERANCE;
 };
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -31,6 +31,9 @@ test('expired - string', function(t) {
   expiration = new Date(Date.now() - (60 * 1000)).toISOString();
   t.true(smartcar.expired(expiration));
 
+  expiration = new Date(Date.now()).toISOString();
+  t.true(smartcar.expired(expiration));
+
   expiration = new Date(Date.now() + (60 * 1000)).toISOString();
   t.false(smartcar.expired(expiration));
 


### PR DESCRIPTION
# Overview

Discovered a bug testing the `node-sdk`. If the token is about to expire, if you make a request after checking it's validity, there's a possibility where the token may be expired at the time of making the request.

# Changes
Added a tolerance to `expire` function and modified appropriate tests.