### PR TITLE
fix(ci): Use GH_TOKEN for deployment in public repo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ jobs:
   include:
     - stage: publish
       node_js: 8
-      script: npm run release
+      script: echo -e "machine github.com\n  login $GH_TOKEN" >> ~/.netrc && npm run release


### PR DESCRIPTION
Using the `GH_TOKEN` for https tag pushes now that node-sdk is public.