### PR TITLE
chore(ci): drop support for node 4, add support for node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language:
   - node_js
 
 node_js:
+  - 10
   - 8
   - 6
-  - 4
 
 cache:
   directories:
@@ -31,5 +31,5 @@ script:
 jobs:
   include:
     - stage: publish
-      node_js: 8
+      node_js: 10
       script: echo -e "machine github.com\n  login $GH_TOKEN" >> ~/.netrc && npm run release

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "nodejs sdk for the smartcar platform",
   "main": "index.js",
   "author": "Smartcar <hello@smartcar.com> (https://smartcar.com)",
-  "license" : "MIT",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/smartcar/node-sdk.git"
@@ -22,7 +22,7 @@
     "index.js"
   ],
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "scripts": {
     "test": "ava",


### PR DESCRIPTION
BREAKING CHANGE: this library will no longer work on node 4,
we support all Node LTS version meaning 6, 8, 10