### PR TITLE
Fix user agent header and include node.js version

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,11 +1,12 @@
 'use strict';
 
-const StatusCodeError = require('request-promise/errors').StatusCodeError;
 const _ = require('lodash');
 const request = require('request-promise');
+const {StatusCodeError} = require('request-promise/errors');
 
 const config = require('./config');
 const errors = require('./errors');
+const {version} = require('../package.json');
 
 const util = {};
 
@@ -52,7 +53,7 @@ util.getUrl = function(id, endpoint) {
 util.request = request.defaults({
   json: true,
   headers: {
-    'User-Agent': `smartcar-node-sdk:${config.version}`,
+    'User-Agent': `smartcar-node-sdk:${version}`,
   },
 });
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const request = require('request-promise');
+const {format} = require('util');
 const {StatusCodeError} = require('request-promise/errors');
 
 const config = require('./config');
@@ -9,6 +10,14 @@ const errors = require('./errors');
 const {version} = require('../package.json');
 
 const util = {};
+
+util.USER_AGENT = format(
+  'Smartcar/%s (%s; %s) Node.js %s',
+  version,
+  process.platform,
+  process.arch,
+  process.version
+);
 
 /**
  * Format Access object and set expiration properties.
@@ -53,7 +62,7 @@ util.getUrl = function(id, endpoint) {
 util.request = request.defaults({
   json: true,
   headers: {
-    'User-Agent': `smartcar-node-sdk:${version}`,
+    'User-Agent': util.USER_AGENT,
   },
 });
 

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const test = require('ava');
 const nock = require('nock');
 const Promise = require('bluebird');
-const StatusCodeError = require('request-promise/errors').StatusCodeError;
+const {StatusCodeError} = require('request-promise/errors');
 
 const util = require('../../lib/util');
 const config = require('../../lib/config');
@@ -63,13 +63,14 @@ test('getUrl - id & endpoint', function(t) {
   t.is(url, API_URL + '/vehicles/VID/odometer');
 });
 
-
 test('request - default opts', async function(t) {
-
   const n = nock('https://mock.com')
     .get('/test')
     .matchHeader('accept', 'application/json')
-    .matchHeader('user-agent', /smartcar-node-sdk:.*/)
+    .matchHeader(
+      'user-agent',
+      /^Smartcar\/(\d+\.\d+\.\d+-[\w-]*) \((\w+); (\w+)\) Node.js v(\d+\.\d+\.\d+)$/
+    )
     .reply(200, {test: 'data'});
 
   const response = await util.request('https://mock.com/test');

--- a/test/lib/vehicle.js
+++ b/test/lib/vehicle.js
@@ -5,11 +5,10 @@ const nock = require('nock');
 const test = require('ava');
 
 const Vehicle = require('../../lib/vehicle');
-const {version} = require('../../package.json');
+const {USER_AGENT} = require('../../lib/util');
 
 const VID = 'ada7207c-3c0a-4027-a47f-6215ce6f7b93';
 const TOKEN = '9ad942c6-32b8-4af2-ada6-5e8ecdbad9c2';
-const USER_AGENT = `smartcar-node-sdk:${version}`;
 
 const vehicle = new Vehicle(VID, TOKEN);
 

--- a/test/lib/vehicle.js
+++ b/test/lib/vehicle.js
@@ -5,11 +5,11 @@ const nock = require('nock');
 const test = require('ava');
 
 const Vehicle = require('../../lib/vehicle');
-const config = require('../../lib/config');
+const {version} = require('../../package.json');
 
 const VID = 'ada7207c-3c0a-4027-a47f-6215ce6f7b93';
 const TOKEN = '9ad942c6-32b8-4af2-ada6-5e8ecdbad9c2';
-const USER_AGENT = `smartcar-node-sdk:${config.version}`;
+const USER_AGENT = `smartcar-node-sdk:${version}`;
 
 const vehicle = new Vehicle(VID, TOKEN);
 


### PR DESCRIPTION
Fixes the `user-agent` header so that it reports the version of the client making the request as opposed to Smartcar API being accessed (which is in the URL) as it currently does.

I also added in the version of node.js that the request was made from for tracking of which node version we should support. Please take a close look at the format of the header as well as if we should be including more or less information in it. (first glance `process.platform` might be useful for windows/osx/linux support)

Format: `smartcar-node-sdk:<pkg-version> (node.js <node-version>)`
Example: `smartcar-node-sdk:3.0.2 (node.js v6.14.3)`

Examples of headers from other API libraries:
- [Sendgrid](https://github.com/sendgrid/sendgrid-nodejs/blob/master/packages/client/src/classes/client.js#L33): `sendgrid/<pkg-version>;nodejs`
- [Twillio](https://github.com/twilio/twilio-node/blob/1bd5ed6c2f42ff3bcc08ae236de577ab3eda2442/lib/rest/Twilio.js#L192) : `twilio-node/<pkg-version> (node.js <node-version>)`
- [Plaid](https://github.com/plaid/plaid-node/blob/master/lib/plaidRequest.js#L55):  `Plaid Node v<pkg-version>`
- [Lob](https://github.com/lob/lob-node/blob/master/lib/index.js#L7): `Lob/v1 NodeBindings/<pkg-version>`
- [PayPal](https://github.com/paypal/PayPal-node-SDK/blob/master/lib/configure.js#L5):  `PayPalSDK/PayPal-node-SDK <pkg-version> (node <node-version>-${process.arch}-${process.platform}; OpenSSL ${process.versions.openssl}`
- [AWS](https://github.com/aws/aws-sdk-js/blob/9c15bf971d40266f3cb7f1d9d63f8a702abb596f/lib/util.js#L32): `aws-sdk-nodejs/<pkg-version> ${process.platform}/<node-version>`
- [Stripe](https://github.com/stripe/stripe-node/blob/34113d273d7db059bd255393c8c6c8983484b323/lib/stripe.js#L13):
```js
JSON.stringify({
  bindings_version: Stripe.PACKAGE_VERSION,
  lang: 'node',
  lang_version: process.version,
  platform: process.platform,
  publisher: 'stripe',
  uname: <output of `uname -a`>
})
```