### PR TITLE
Change development option to mode option

### DIFF
--- a/lib/auth-client.js
+++ b/lib/auth-client.js
@@ -46,8 +46,9 @@ const config = require('./config');
  * requires. This will default to requiring all scopes. The valid permission
  * names are found in the
  * [API Reference](https://smartcar.com/docs#get-all-vehicles).
- * @param {Boolean} [options.testMode=false] - Launch Smartcar auth in
- * test mode to enable the mock vehicle brand.
+ * @param {Boolean} [options.testMode=false] - Launch Smartcar auth flow in
+ * test mode.
+ * [API Reference](https://smartcar.com/docs#request-authorization).
  * @param {Boolean} [options.development=false] - DEPRECATED: Launch Smartcar auth in
  * development mode to enable the mock vehicle brand.
  */

--- a/lib/auth-client.js
+++ b/lib/auth-client.js
@@ -46,7 +46,9 @@ const config = require('./config');
  * requires. This will default to requiring all scopes. The valid permission
  * names are found in the
  * [API Reference](https://smartcar.com/docs#get-all-vehicles).
- * @param {Boolean} [options.development=false] - Launch Smartcar auth in
+ * @param {Boolean} [options.testMode=false] - Launch Smartcar auth in
+ * test mode to enable the mock vehicle brand.
+ * @param {Boolean} [options.development=false] - DEPRECATED: Launch Smartcar auth in
  * development mode to enable the mock vehicle brand.
  */
 function AuthClient(options) {
@@ -65,6 +67,7 @@ function AuthClient(options) {
     redirectUri: Joi.string().uri().required(),
     scope: Joi.array().items(Joi.string()),
     development: Joi.boolean(),
+    testMode: Joi.boolean(),
   });
 
   Joi.assert(options, schema);
@@ -73,7 +76,16 @@ function AuthClient(options) {
   this.clientSecret = options.clientSecret;
   this.redirectUri = options.redirectUri;
   this.scope = options.scope;
-  this.development = options.development || false;
+
+  if (options.development !== undefined) {
+    /* eslint-disable-next-line no-console */
+    console.warn(`DeprecationWarning: development flag is deprecated.
+      This is discouraged and will be removed in the next major release.
+      Use testMode instead`);
+    this.development = options.development;
+  }
+
+  this.testMode = options.testMode || false;
 
   this.request = util.request.defaults({
     baseUrl: config.auth,
@@ -132,9 +144,13 @@ AuthClient.prototype.getAuthUrl = function(options) {
     parameters.state = options.state;
   }
 
-  if (this.development) {
-    parameters.mock = true;
+  let mode;
+  if (this.development !== undefined) {
+    mode = this.development;
+  } else {
+    mode = this.testMode;
   }
+  parameters.mode = mode ? 'test' : 'live';
 
   const query = qs.stringify(parameters);
 

--- a/test/end-to-end/helpers/index.js
+++ b/test/end-to-end/helpers/index.js
@@ -13,7 +13,7 @@ helpers.getAuthClientParams = function() {
     // eslint-disable-next-line no-process-env
     clientSecret: process.env.INTEGRATION_CLIENT_SECRET,
     redirectUri: 'https://example.com/auth',
-    development: true,
+    testMode: true,
   };
 };
 

--- a/test/unit/lib/auth-client.js
+++ b/test/unit/lib/auth-client.js
@@ -23,7 +23,7 @@ test('constructor', function(t) {
   t.is(client.clientSecret, CLIENT_SECRET);
   t.is(client.redirectUri, 'https://insurance.co/callback');
   t.deepEqual(client.scope, ['read_odometer', 'read_vehicle_info']);
-  t.is(client.development, false);
+  t.is(client.testMode, false);
   t.true('request' in client);
 
 });
@@ -98,6 +98,7 @@ test('getAuthUrl - simple', function(t) {
   expected += '&redirect_uri=https%3A%2F%2Finsurance.co%2Fcallback';
   expected += '&approval_prompt=auto';
   expected += '&scope=read_odometer%20read_vehicle_info';
+  expected += '&mode=live';
 
   t.is(actual, expected);
 
@@ -122,6 +123,7 @@ test('getAuthUrl - no scope', function(t) {
   expected += '&redirect_uri=https%3A%2F%2Finsurance.co%2Fcallback';
   expected += '&approval_prompt=force';
   expected += '&state=fakestate';
+  expected += '&mode=live';
 
   t.is(actual, expected);
 
@@ -148,12 +150,69 @@ test('getAuthUrl - state & approval prompt', function(t) {
   expected += '&approval_prompt=force';
   expected += '&scope=read_odometer%20read_vehicle_info';
   expected += '&state=fakestate';
+  expected += '&mode=live';
 
   t.is(actual, expected);
 
 });
 
-test('getAuthUrl - development mode', function(t) {
+test('getAuthUrl - test mode true', function(t) {
+
+  const client = new AuthClient({
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    redirectUri: 'https://insurance.co/callback',
+    scope: ['read_odometer', 'read_vehicle_info'],
+    testMode: true,
+  });
+
+  const actual = client.getAuthUrl({
+    scope: 'this should be ignored',
+    state: 'fakestate',
+    forcePrompt: true,
+  });
+
+  let expected = 'https://connect.smartcar.com/oauth/authorize?';
+  expected += `response_type=code&client_id=${CLIENT_ID}`;
+  expected += '&redirect_uri=https%3A%2F%2Finsurance.co%2Fcallback';
+  expected += '&approval_prompt=force';
+  expected += '&scope=read_odometer%20read_vehicle_info';
+  expected += '&state=fakestate';
+  expected += '&mode=test';
+
+  t.is(actual, expected);
+
+});
+
+test('getAuthUrl - test mode false', function(t) {
+
+  const client = new AuthClient({
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    redirectUri: 'https://insurance.co/callback',
+    scope: ['read_odometer', 'read_vehicle_info'],
+    testMode: false,
+  });
+
+  const actual = client.getAuthUrl({
+    scope: 'this should be ignored',
+    state: 'fakestate',
+    forcePrompt: true,
+  });
+
+  let expected = 'https://connect.smartcar.com/oauth/authorize?';
+  expected += `response_type=code&client_id=${CLIENT_ID}`;
+  expected += '&redirect_uri=https%3A%2F%2Finsurance.co%2Fcallback';
+  expected += '&approval_prompt=force';
+  expected += '&scope=read_odometer%20read_vehicle_info';
+  expected += '&state=fakestate';
+  expected += '&mode=live';
+
+  t.is(actual, expected);
+
+});
+
+test('getAuthUrl - deprecated development mode', function(t) {
 
   const client = new AuthClient({
     clientId: CLIENT_ID,
@@ -175,13 +234,13 @@ test('getAuthUrl - development mode', function(t) {
   expected += '&approval_prompt=force';
   expected += '&scope=read_odometer%20read_vehicle_info';
   expected += '&state=fakestate';
-  expected += '&mock=true';
+  expected += '&mode=test';
 
   t.is(actual, expected);
 
 });
 
-test('getAuthUrl - development mode false', function(t) {
+test('getAuthUrl - deprecated development mode false', function(t) {
 
   const client = new AuthClient({
     clientId: CLIENT_ID,
@@ -203,6 +262,7 @@ test('getAuthUrl - development mode false', function(t) {
   expected += '&approval_prompt=force';
   expected += '&scope=read_odometer%20read_vehicle_info';
   expected += '&state=fakestate';
+  expected += '&mode=live';
 
   t.is(actual, expected);
 


### PR DESCRIPTION
Deprecated `development` option. Updated JSDoc and added `console.warn` message.

Added `testMode` boolean option which gets converted to `live` or `test`.

## Tests
Updated and added unit tests. 