### PR TITLE
fix(getAuthUrl): Revert getAuthUrl testMode change.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,6 @@ Session.vim
 [._]s[a-w][a-z]
 [._]*.]s[a-w][a-z]]
 
-## Webstorm
-.idea
-
 ## Sublime
 *.tmlanguage.cache
 *.tmPreferences.cache

--- a/lib/auth-client.js
+++ b/lib/auth-client.js
@@ -114,8 +114,6 @@ function AuthClient(options) {
  * `true` will show the permissions approval screen on every authentication
  * attempt, even if the user has previously consented to the exact scope of
  * permissions.
- * @param {Boolean} [options.testMode=false] - Launch the Smartcar auth flow in
- * test mode.
  * @return {String} OAuth authorization URL to direct user to.
  * @example
  * https://connect.smartcar.com/oauth/authorize?
@@ -148,17 +146,11 @@ AuthClient.prototype.getAuthUrl = function(options) {
   }
 
   let mode;
-  if (options.testMode !== undefined) {
-    // Override mode with testMode option.
-    mode = options.testMode;
-  } else if (this.development !== undefined) {
-    // Use deprecated 'development' flag.
+  if (this.development !== undefined) {
     mode = this.development;
   } else {
-    // Use 'testMode' flag.
     mode = this.testMode;
   }
-
   parameters.mode = mode ? 'test' : 'live';
 
   const query = qs.stringify(parameters);

--- a/test/unit/lib/auth-client.js
+++ b/test/unit/lib/auth-client.js
@@ -212,64 +212,6 @@ test('getAuthUrl - test mode false', function(t) {
 
 });
 
-test('getAuthUrl - test mode overrides constructor testMode value - true', function(t) {
-
-  const client = new AuthClient({
-    clientId: CLIENT_ID,
-    clientSecret: CLIENT_SECRET,
-    redirectUri: 'https://insurance.co/callback',
-    scope: ['read_odometer', 'read_vehicle_info'],
-    testMode: true,
-  });
-
-  const actual = client.getAuthUrl({
-    scope: 'this should be ignored',
-    state: 'fakestate',
-    forcePrompt: true,
-    testMode: false,
-  });
-
-  let expected = 'https://connect.smartcar.com/oauth/authorize?';
-  expected += `response_type=code&client_id=${CLIENT_ID}`;
-  expected += '&redirect_uri=https%3A%2F%2Finsurance.co%2Fcallback';
-  expected += '&approval_prompt=force';
-  expected += '&scope=read_odometer%20read_vehicle_info';
-  expected += '&state=fakestate';
-  expected += '&mode=live';
-
-  t.is(actual, expected);
-
-});
-
-test('getAuthUrl - test mode overrides constructor testMode value - false', function(t) {
-
-  const client = new AuthClient({
-    clientId: CLIENT_ID,
-    clientSecret: CLIENT_SECRET,
-    redirectUri: 'https://insurance.co/callback',
-    scope: ['read_odometer', 'read_vehicle_info'],
-    testMode: false,
-  });
-
-  const actual = client.getAuthUrl({
-    scope: 'this should be ignored',
-    state: 'fakestate',
-    forcePrompt: true,
-    testMode: true,
-  });
-
-  let expected = 'https://connect.smartcar.com/oauth/authorize?';
-  expected += `response_type=code&client_id=${CLIENT_ID}`;
-  expected += '&redirect_uri=https%3A%2F%2Finsurance.co%2Fcallback';
-  expected += '&approval_prompt=force';
-  expected += '&scope=read_odometer%20read_vehicle_info';
-  expected += '&state=fakestate';
-  expected += '&mode=test';
-
-  t.is(actual, expected);
-
-});
-
 test('getAuthUrl - deprecated development mode', function(t) {
 
   const client = new AuthClient({


### PR DESCRIPTION
This reverts commit 9ca100d8f50d1f0c76362d45f2c330e4f048cce5.

## Reasoning
- testMode flag override was added as an options parameter to `getAuthUrl()` (https://github.com/smartcar/node-sdk/pull/64). However, a developer should only be able to specify test or live mode from the constructor.