### PR TITLE
Bump joi version to remove deprecated version of hoek

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "bluebird": "^3.5.1",
-    "joi": "^14.1.0",
+    "joi": "^14.0.3",
     "lodash": "^4.17.5",
     "request": "^2.83.0",
     "request-promise": "^4.2.2"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "bluebird": "^3.5.1",
-    "joi": "^13.4.0",
+    "joi": "^14.1.0",
     "lodash": "^4.17.5",
     "request": "^2.83.0",
     "request-promise": "^4.2.2"


### PR DESCRIPTION
When installing the [`smartcar/demo`](https://github.com/smartcar/demo.git) app, I noticed the warning message for an unmaintained version of `hoek` -
```
$ npm install
npm WARN deprecated hoek@5.0.4: This version is no longer maintained. Please upgrade to the latest version.
smartcar-node-demo@0.2.1 /mnt/c/Users/erik/Documents/Development/demo/node
...
```
The [version update](https://github.com/hapijs/joi/commit/5b53a2296cf2e578c81c75b6d69ae6c57783cf7b) was included in v14.0.3. I'm updating this library to the minimum version required to remove this warning.