### PR TITLE
fix(SmartcarErrorV2): use `request.uri` to determine version

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -75,7 +75,7 @@ util.catch = function(caught) {
   const options = caught.options;
   const body = _.get(caught, 'response.body', {});
 
-  if (options.uri.includes('/v2.0/')) {
+  if (caught.response.request.uri.href.includes('/v2.0/')) {
     throw new errors.SmartcarErrorV2(body);
   }
 


### PR DESCRIPTION
`options.uri` does not contain any portions of the uri that are in the
`baseUrl`
