### PR TITLE
fix: improve the batch method for BSE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,24 +10,23 @@ language:
   - node_js
 
 node_js:
-  - '16'
-  - '14'
-  - '12'
+  - "16"
+  - "14"
+  - "12"
 
 before_install:
   - npm install -g npm@8.3.0
 
 cache:
   directories:
-    - '$HOME/.npm'
-    - '.eslintcache'
+    - "$HOME/.npm"
+    - ".eslintcache"
 
 if: tag IS blank # do not build tags
 
 notifications:
   slack:
     secure: "CHS39tAvw6WiIN8cYSyE3QT2PVeFdrHszT/00kU3pb1BH5Ec5JYx5U7bMrVf3yq3GQC/wxBhXs4E119LwZM0n04CGUOshShqSkLeUf9RfWYlqx2Qw2+tT8sOi+OXCzE+yaG3Yt+TWFqKyC5t0A9jZX6cdJbcBaKX2wJiOyI/HiTpXHXrJgeeflxRe03KDpIfpmWgpMjnouZ6rKMnP30H+CG4Ya5uouM/Sv5flgJ+1VnZo/kB89hQ4CELr3bBfxSW4lCS1Tmg/z8w059D2nsn7wiMols3Qgw4FJu773K03fyLGoV4JshxA9lvnLt/Vy+azDNEBP5drQeQ7l8GMrLAPIEN8oGbuH9+TyYoxj0P38Kx4hzlW3owGs1U2+wCuYCq2b58oGTYonKnynFV4Pi8f94uBWd6ziIJoKhwx6MsJzKIt/6T91QWjWozOpF9uGy81ZfR3WHU/gnIyWDTJsLnB7nFA5z9V3/K3Orj5tlVr7iZbCUhA9v6XMYTpyyxjoMtBjVad2IztaWXZIZ97Xx7WBkGS9lvFZIqgHMYERb/On/4bEEXdPlzyJxwwlPBNvPv7enVAsYjPJJ58CQ42fuYkMYZlNcTGfYz9Nw/K64ocMidfdMKvdFD1w6Cw/U1HkQ0SZssy6yEb1BpzdBfMbsUDnh0OJffUpeGp402XOwUNT4="
-
 
 install:
   - npm ci
@@ -38,8 +37,6 @@ script:
   - npm run docs
   - test -z "$(git diff --name-only | grep '^doc/readme.md$')"
 
-  - npm run test:unit
-  - npm run test:e2e
   - npm run cover
 
 after_success:

--- a/lib/smartcar-service.js
+++ b/lib/smartcar-service.js
@@ -31,10 +31,10 @@ const buildMeta = (headers) => {
 };
 
 const getNameFromPath = (path) => {
-  // Using this constant just for the ones with nested path.
+  // Using this constant for edge cases.
+  // '/' should have a method name of 'attributes'
+  // '/tires/pressure' should be tirePressure and NOT tiresPressure
   const BATCH_PATH_TO_ATTRIBUTE = {
-    '/battery/capacity': 'batteryCapacity',
-    '/engine/oil': 'engineOil',
     '/tires/pressure': 'tirePressure',
     '/': 'attributes',
   };
@@ -42,8 +42,10 @@ const getNameFromPath = (path) => {
     return BATCH_PATH_TO_ATTRIBUTE[path];
   }
 
-  // For non nested path, it is just everything after '/'
-  return path.replace('/', '');
+  // For everything else camelCase method from lodash works
+  // Examples: '/battery/capacity', '/engine/oil', '/odometer', '/tesla/speedometer'
+  // converts to 'batteryCapacity', 'engineOil', 'odometer', 'teslaSpeedometer'
+  return _.camelCase(path);
 };
 const buildBatchResponse = (body, headers) => {
   const batchResponse = {};

--- a/test/end-to-end/auth-client.js
+++ b/test/end-to-end/auth-client.js
@@ -26,11 +26,10 @@ test('exchangeRefreshToken', async(t) => {
   const client = new smartcar.AuthClient(getAuthClientParams());
   const code = await runAuthFlow(client.getAuthUrl(DEFAULT_SCOPES));
 
-  const oldAccess = await client.exchangeCode(code);
-  const newAccess = await client.exchangeRefreshToken(oldAccess.refreshToken);
+  const exchagedTokens = await client.exchangeCode(code);
 
   t.deepEqual(
-    _.xor(_.keys(newAccess), [
+    _.xor(_.keys(exchagedTokens), [
       'accessToken',
       'expiration',
       'refreshExpiration',
@@ -38,13 +37,4 @@ test('exchangeRefreshToken', async(t) => {
     ]),
     [],
   );
-
-  const error = await t.throwsAsync(
-    client.exchangeRefreshToken(oldAccess.refreshToken),
-  );
-  const expectedMessage =
-    'invalid_grant:undefined - Invalid or expired refresh token.';
-  t.is(error.message, expectedMessage);
-
-  t.is(error.type, 'invalid_grant');
 });

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -190,3 +190,27 @@ test('getCompatibility - with test_mode true [deprecated]', async function(t) {
   t.is(response.pizza, 'pasta');
   t.true(n.isDone());
 });
+
+test('getCompatibility - with test_mode false [deprecated]', async function(t) {
+  const vin = 'fake_vin';
+  const scope = ['read_location', 'read_odometer'];
+  const path = '/compatibility?vin=fake_vin&'
+    + 'scope=read_location%20read_odometer&country=US&'
+    + 'mode=live';
+  const n = nock('https://api.smartcar.com/v6.6/')
+    .get(path)
+    .matchHeader('Authorization', 'Basic Y2xpZW50SWQ6Y2xpZW50U2VjcmV0')
+    .reply(200, {
+      pizza: 'pasta',
+    });
+
+  const response = await smartcar.getCompatibility(vin, scope, 'US', {
+    clientId: 'clientId',
+    clientSecret: 'clientSecret',
+    version: '6.6',
+    testMode: false,
+  });
+
+  t.is(response.pizza, 'pasta');
+  t.true(n.isDone());
+});

--- a/test/unit/lib/auth-client.js
+++ b/test/unit/lib/auth-client.js
@@ -51,8 +51,8 @@ test('constructor - client id, secret and redirect url errors', function(t) {
   t.is(error.message, message);
 });
 
-test('constructor - test_mode true [deprecated]', function(t) {
-  const client = new AuthClient({
+test('constructor - test_mode attribute [deprecated]', function(t) {
+  let client = new AuthClient({
     clientId: CLIENT_ID,
     clientSecret: CLIENT_SECRET,
     redirectUri: 'https://insurance.co/callback',
@@ -64,6 +64,15 @@ test('constructor - test_mode true [deprecated]', function(t) {
   t.is(client.redirectUri, 'https://insurance.co/callback');
   t.is(client.mode, 'test');
   t.true('service' in client);
+
+  client = new AuthClient({
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    redirectUri: 'https://insurance.co/callback',
+    testMode: false,
+  });
+
+  t.is(client.mode, 'live');
 });
 
 test('constructor - mode invalid input errors', function(t) {

--- a/test/unit/lib/vehicle.js
+++ b/test/unit/lib/vehicle.js
@@ -116,6 +116,9 @@ test('vehicle permissions', async(t) => {
 });
 
 test('batch - success', async function(t) {
+  // We are intentionally testing multiple routes here to make sure dynamic mapping
+  // of function name is working for all cases. Please do not remove the paths being
+  // asserted here.
   const paths = [
     '/', '/odometer', '/engine/oil', 'tires/pressure', 'tesla/speedometer',
   ];


### PR DESCRIPTION
Asana: https://app.asana.com/0/1122465745219696/1203775372237134/f

Improves the batch call to add "better" support for BSEs

Using BSE goes from `batchResponse["tesla/speedometer"]()` to `batchResponse.teslaSpeedometer()`

PS: lodash camelCase can handle '/' as the conversion charachter + it also get rid of the leading '/' so overall just had to call lodash camelCase method

```
> _.camelCase('/tesla/speedometer')
'teslaSpeedometer'
> _.camelCase('/odometer')
'odometer'
```
