### PR TITLE
feat: add browser configuration for test environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Note: In order to run tests locally the following environment variables would ha
 - `E2E_SMARTCAR_CLIENT_SECRET` - Client secret to be used.
 - `E2E_SMARTCAR_AMT` - AMT from dashboard for webhooks tests.
 - `E2E_SMARTCAR_WEBHOOK_ID` - Webhook ID use in the webhook tests success case.
+- `BROWSER` - Web browser for tests (`chrome` or `firefox`, default: `firefox`).
+
 
 Your application needs to have https://example.com/auth set as a valid redirect URI
 

--- a/test/end-to-end/helpers/index.js
+++ b/test/end-to-end/helpers/index.js
@@ -13,6 +13,8 @@ const helpers = {};
 const HEADLESS = isCI || process.env.HEADLESS;
 const CLIENT_ID = process.env.E2E_SMARTCAR_CLIENT_ID;
 const CLIENT_SECRET = process.env.E2E_SMARTCAR_CLIENT_SECRET;
+const BROWSER = process.env.BROWSER || 'firefox';
+
 /* eslint-enable */
 
 if (!CLIENT_ID || !CLIENT_SECRET) {
@@ -74,7 +76,7 @@ helpers.runAuthFlow = async function(
   const driver = new Builder()
     .setChromeOptions(chromeOptions)
     .setFirefoxOptions(firefoxOptions)
-    .forBrowser('firefox')
+    .forBrowser(BROWSER)
     .build();
 
   await driver.get(authUrl);


### PR DESCRIPTION
This PR introduces the ability to configure the web browser used for running tests via an environment variable `BROWSER`. The valid options for this variable are 'chrome' and 'firefox', with 'firefox' set as the default browser if no environment variable is explicitly defined.

**Changes:**
- Added `BROWSER` environment variable configuration to the README, enabling users to choose between Google Chrome or Mozilla Firefox for test executions.
 