### PR TITLE
chore(dependencies): remove request dependency

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -37,7 +37,7 @@ util.formatAccess = function(access) {
 };
 
 /**
- * Form an API request URI
+ * Form an API request URI.
  *
  * @param {String} id vehicle identifier
  * @param {String} endpoint API endpoint


### PR DESCRIPTION
Remove the deprecated depedencies request and request-promise

BREAKING CHANGE: uses the builtin fetch and
removes support for node versions <18.20.0